### PR TITLE
all datatypes for blackhole adapter

### DIFF
--- a/src/BlackHole.php
+++ b/src/BlackHole.php
@@ -355,7 +355,19 @@ class BlackHole implements
         if ($this->capabilities === null) {
             // use default capabilities only
             $this->capabilityMarker = new stdClass();
-            $this->capabilities     = new Capabilities($this, $this->capabilityMarker);
+            $this->capabilities     = new Capabilities($this, $this->capabilityMarker, [
+                'supportedDatatypes' => [
+                    'NULL'     => true,
+                    'boolean'  => true,
+                    'integer'  => true,
+                    'double'   => true,
+                    'string'   => true,
+                    'array'    => true,
+                    'object'   => true,
+                    'resource' => true,
+                    'light'    => true
+                ],
+            ]);
         }
         return $this->capabilities;
     }

--- a/src/BlackHole.php
+++ b/src/BlackHole.php
@@ -50,7 +50,7 @@ class BlackHole implements
     /**
      * options
      *
-     * @var null|AdapterOptions
+     * @var null|BlackHoleOptions
      */
     protected $options;
 
@@ -75,8 +75,8 @@ class BlackHole implements
     public function setOptions($options)
     {
         if ($this->options !== $options) {
-            if (! $options instanceof AdapterOptions) {
-                $options = new AdapterOptions($options);
+            if (! $options instanceof BlackHoleOptions) {
+                $options = new BlackHoleOptions($options);
             }
 
             if ($this->options) {
@@ -91,12 +91,12 @@ class BlackHole implements
     /**
      * Get options
      *
-     * @return AdapterOptions
+     * @return BlackHoleOptions
      */
     public function getOptions()
     {
         if (! $this->options) {
-            $this->setOptions(new AdapterOptions());
+            $this->setOptions(new BlackHoleOptions());
         }
         return $this->options;
     }
@@ -353,6 +353,7 @@ class BlackHole implements
     public function getCapabilities()
     {
         if ($this->capabilities === null) {
+            $options = $this->getOptions();
             // use default capabilities only
             $this->capabilityMarker = new stdClass();
             $this->capabilities     = new Capabilities($this, $this->capabilityMarker, [
@@ -367,6 +368,8 @@ class BlackHole implements
                     'resource' => true,
                     'light'    => true
                 ],
+                'staticTtl' => $options->isPsrCompatible(),
+                'minTtl' => (int) $options->isPsrCompatible()
             ]);
         }
         return $this->capabilities;
@@ -394,6 +397,10 @@ class BlackHole implements
      */
     public function clearByNamespace($namespace)
     {
+        if ($this->getOptions()->isPsrCompatible()) {
+            return true;
+        }
+
         return false;
     }
 
@@ -431,6 +438,10 @@ class BlackHole implements
      */
     public function flush()
     {
+        if ($this->getOptions()->isPsrCompatible()) {
+            return true;
+        }
+
         return false;
     }
 

--- a/src/BlackHoleOptions.php
+++ b/src/BlackHoleOptions.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace Laminas\Cache\Storage\Adapter;
+
+final class BlackHoleOptions extends AdapterOptions
+{
+    /**
+     * Flag to optionally allow PSR compatibility.
+     * This flag is necessary due to the fact that providing proper PSR support without BC
+     * breaks wont be possible otherwise.
+     * @var bool
+     */
+    protected $psr = false;
+
+    /**
+     * @return bool
+     * @internal
+     */
+    public function isPsrCompatible()
+    {
+        return $this->psr;
+    }
+
+    /**
+     * @param bool $psr
+     * @return void
+     * @internal
+     */
+    public function setPsr($psr)
+    {
+        $this->psr = (bool) $psr;
+    }
+}

--- a/test/integration/Psr/CacheItemPool/BlackHoleIntegrationTest.php
+++ b/test/integration/Psr/CacheItemPool/BlackHoleIntegrationTest.php
@@ -6,20 +6,48 @@
  * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
  */
 
-namespace LaminasTest\Cache\Psr\CacheItemPool;
+namespace LaminasTest\Cache\Storage\Adapter\Psr\CacheItemPool;
 
+use Cache\IntegrationTests\CachePoolTest;
 use Laminas\Cache\Psr\CacheItemPool\CacheItemPoolDecorator;
-use Laminas\Cache\StorageFactory;
-use PHPUnit\Framework\TestCase;
+use Laminas\Cache\Storage\Adapter\BlackHole;
 
-class BlackHoleIntegrationTest extends TestCase
+final class BlackHoleIntegrationTest extends CachePoolTest
 {
-    /**
-     * @expectedException \Laminas\Cache\Psr\CacheItemPool\CacheException
-     */
-    public function testAdapterNotSupported()
+    const TEST_NOT_SUPPORTED_REASON = 'BlackHole never caches.';
+
+    protected $skippedTests = [
+        'testBasicUsage' => self::TEST_NOT_SUPPORTED_REASON,
+        'testGetItem' => self::TEST_NOT_SUPPORTED_REASON,
+        'testGetItems' => self::TEST_NOT_SUPPORTED_REASON,
+        'testHasItem' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDeleteItems' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSave' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSaveWithoutExpire' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDeferredSave' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDeferredSaveWithoutCommit' => self::TEST_NOT_SUPPORTED_REASON,
+        'testCommit' => self::TEST_NOT_SUPPORTED_REASON,
+        'testExpiresAt' => self::TEST_NOT_SUPPORTED_REASON,
+        'testExpiresAtWithNull' => self::TEST_NOT_SUPPORTED_REASON,
+        'testExpiresAfterWithNull' => self::TEST_NOT_SUPPORTED_REASON,
+        'testKeyLength' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeString' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeInteger' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeNull' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeFloat' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeBoolean' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeArray' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeObject' => self::TEST_NOT_SUPPORTED_REASON,
+        'testIsHit' => self::TEST_NOT_SUPPORTED_REASON,
+        'testIsHitDeferred' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSaveDeferredWhenChangingValues' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSaveDeferredOverwrite' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSavingObject' => self::TEST_NOT_SUPPORTED_REASON,
+        'testHasItemReturnsFalseWhenDeferredItemIsExpired' => self::TEST_NOT_SUPPORTED_REASON,
+    ];
+
+    public function createCachePool()
     {
-        $storage = StorageFactory::adapterFactory('blackhole');
-        new CacheItemPoolDecorator($storage);
+        return new CacheItemPoolDecorator(new BlackHole(['psr' => true]));
     }
 }

--- a/test/integration/Psr/SimpleCache/BlackHoleIntegrationTest.php
+++ b/test/integration/Psr/SimpleCache/BlackHoleIntegrationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Cache\Storage\Adapter\Psr\SimpleCache;
+
+use Cache\IntegrationTests\SimpleCacheTest;
+use Laminas\Cache\Psr\SimpleCache\SimpleCacheDecorator;
+use Laminas\Cache\Storage\Adapter\BlackHole;
+
+final class BlackHoleIntegrationTest extends SimpleCacheTest
+{
+    const TEST_NOT_SUPPORTED_REASON = 'BlackHole never caches.';
+
+    protected $skippedTests = [
+        'testSet' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetMultipleValidData' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetValidData' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetMultipleValidKeys' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetValidKeys' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeObject' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeArray' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeBoolean' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeFloat' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeInteger' => self::TEST_NOT_SUPPORTED_REASON,
+        'testDataTypeString' => self::TEST_NOT_SUPPORTED_REASON,
+        'testHas' => self::TEST_NOT_SUPPORTED_REASON,
+        'testGetMultipleWithGenerator' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetMultipleWithGenerator' => self::TEST_NOT_SUPPORTED_REASON,
+        'testGetMultiple' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetMultipleTtl' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetMultiple' => self::TEST_NOT_SUPPORTED_REASON,
+        'testGet' => self::TEST_NOT_SUPPORTED_REASON,
+        'testSetTtl' => self::TEST_NOT_SUPPORTED_REASON,
+        'testObjectDoesNotChangeInCache' => self::TEST_NOT_SUPPORTED_REASON,
+    ];
+
+    public function createSimpleCache()
+    {
+        return new SimpleCacheDecorator(new BlackHole([
+            'psr' => true,
+        ]));
+    }
+
+    public function testCanClearWithoutNamespace()
+    {
+        $cache = new SimpleCacheDecorator(new BlackHole([
+            'psr' => true,
+            'namespace' => '',
+        ]));
+
+        self::assertTrue($cache->clear());
+    }
+}

--- a/test/unit/BlackHoleOptionsTest.php
+++ b/test/unit/BlackHoleOptionsTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cache for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cache/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cache/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Cache\Storage\Adapter;
+
+use Laminas\Cache\Storage\Adapter\BlackHoleOptions;
+use PHPUnit\Framework\TestCase;
+
+final class BlackHoleOptionsTest extends TestCase
+{
+    public function testWillPassConstructValuesToProperties()
+    {
+        $options = new BlackHoleOptions([
+            'psr' => true,
+        ]);
+
+        self::assertTrue($options->isPsrCompatible());
+    }
+
+    public function testPsrCompatibilityIsDisabledByDefault()
+    {
+        $options = new BlackHoleOptions();
+        self::assertFalse($options->isPsrCompatible());
+    }
+
+    public function testWillSetPsrOption()
+    {
+        $options = new BlackHoleOptions();
+        self::assertFalse($options->isPsrCompatible());
+        $options->setPsr(true);
+        self::assertTrue($options->isPsrCompatible());
+    }
+}

--- a/test/unit/BlackHoleTest.php
+++ b/test/unit/BlackHoleTest.php
@@ -169,4 +169,14 @@ class BlackHoleTest extends TestCase
         $this->assertInstanceOf('Laminas\Cache\Storage\TotalSpaceCapableInterface', $this->storage);
         $this->assertSame(0, $this->storage->getTotalSpace());
     }
+
+    public function testSupportedDataTypes()
+    {
+        $capabilities = $this->storage->getCapabilities();
+        $supportedDataTypes = $capabilities->getSupportedDatatypes();
+        $this->assertNotEmpty($supportedDataTypes);
+        foreach ($supportedDataTypes as $supportedDataType) {
+            $this->assertTrue($supportedDataType);
+        }
+    }
 }

--- a/test/unit/BlackHoleTest.php
+++ b/test/unit/BlackHoleTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\Cache\Storage\Adapter;
 
 use Laminas\Cache\Storage\Adapter\BlackHole;
+use Laminas\Cache\Storage\Adapter\BlackHoleOptions;
 use Laminas\Cache\Storage\AdapterPluginManager;
 use Laminas\Cache\StorageFactory;
 use Laminas\ServiceManager\ServiceManager;
@@ -178,5 +179,36 @@ class BlackHoleTest extends TestCase
         foreach ($supportedDataTypes as $supportedDataType) {
             $this->assertTrue($supportedDataType);
         }
+    }
+
+    public function testSetOptionsCreatesBlackHoleOptions()
+    {
+        $this->storage->setOptions([]);
+        $this->assertInstanceOf(BlackHoleOptions::class, $this->storage->getOptions());
+    }
+
+    public function testGetOptionsReturnsBlackHoleOptions()
+    {
+        $this->assertInstanceOf(BlackHoleOptions::class, $this->storage->getOptions());
+    }
+
+    public function testConstructorPassesBlackHoleOptions()
+    {
+        $cache = new BlackHole(['psr' => true]);
+        $options = $cache->getOptions();
+        $this->assertInstanceOf(BlackHoleOptions::class, $options);
+        $this->assertTrue($options->isPsrCompatible());
+    }
+
+    public function testFlushReturnsTrueWhenPsrCompatibilityIsEnabled()
+    {
+        $cache = new BlackHole(['psr' => true]);
+        $this->assertTrue($cache->flush());
+    }
+
+    public function testClearByNamespaceReturnsTrueWhenPsrCompatibilityIsEnabled()
+    {
+        $cache = new BlackHole(['psr' => true]);
+        $this->assertTrue($cache->clearByNamespace('foo'));
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

```php
...could not be created. Reason: The storage adapter "Zend\Cache\Storage\Adapter\BlackHole" requires a serializer plugin; please see https://docs.zendframework.com/zend-cache/storage/plugin/#quick-start for details on how to attach the plugin to your adapter.
```

```php
... could not be created. Reason: The adapter 'Zend\Cache\Storage\Adapter\BlackHole' doesn't implement 'Zend\EventManager\EventsCapableInterface' and therefore can't handle plugins
```

Blackhole adapter now accepts all datatypes and doesn't need a serializer anymore. Otherwise you have to implement the EventSystem but I don't think that's necessary because blackhole doesn't save anything anyway.