### PR TITLE
bugfix: PSR compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   },
   "require-dev": {
     "laminas/laminas-cache": "^2.10",
-    "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
+    "laminas/laminas-cache-storage-adapter-test": "1.0.2",
     "laminas/laminas-coding-standard": "~1.0.0",
     "squizlabs/php_codesniffer": "^2.7"
   },

--- a/src/BlackHole.php
+++ b/src/BlackHole.php
@@ -296,6 +296,10 @@ class BlackHole implements
      */
     public function removeItems(array $keys)
     {
+        if ($this->getOptions()->isPsrCompatible()) {
+            return [];
+        }
+
         return $keys;
     }
 

--- a/test/unit/BlackHoleTest.php
+++ b/test/unit/BlackHoleTest.php
@@ -211,4 +211,10 @@ class BlackHoleTest extends TestCase
         $cache = new BlackHole(['psr' => true]);
         $this->assertTrue($cache->clearByNamespace('foo'));
     }
+
+    public function testRemoveItemsReturnsEmptyListOfStringsWhenPsrCompatibilityIsEnabled()
+    {
+        $cache = new BlackHole(['psr' => true]);
+        $this->assertEquals([], $cache->removeItems([]));
+    }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | no

### Description

With `laminas-cache` v2.10.2, a bugfix was released which properly detects successful deletions of cache items.
Due to that fix, this adapter does not fully work with PSR-16 anymore and thus, this fix will re-add proper support.
