### PR TITLE
Normalize composer-dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,17 @@
   ],
   "license": "BSD-3-Clause",
   "require": {
-    "php": "^7.3 || ~8.0.0 || ~8.1.0",
+    "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
     "laminas/laminas-cache": "^3.0"
   },
   "provide": {
     "laminas/laminas-cache-storage-implementation": "1.0"
   },
+  "conflict": {
+    "laminas/laminas-servicemanager": "<3.11"
+  },
   "require-dev": {
-    "laminas/laminas-cache": "3.0.x-dev",
-    "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev",
+    "laminas/laminas-cache-storage-adapter-test": "^2.3",
     "laminas/laminas-coding-standard": "~2.3.0",
     "psalm/plugin-phpunit": "^0.17.0",
     "vimeo/psalm": "^4.9"
@@ -23,7 +25,7 @@
   "config": {
     "sort-packages": true,
     "platform": {
-      "php": "7.3.99"
+      "php": "7.4.99"
     },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,56 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d7167795240077ee456f56ae5a1664a3",
+    "content-hash": "29159be47392e494285f997507304f06",
     "packages": [
         {
-            "name": "container-interop/container-interop",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/container-interop/container-interop.git",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
-                "shasum": ""
-            },
-            "require": {
-                "psr/container": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Interop\\Container\\": "src/Interop/Container/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "homepage": "https://github.com/container-interop/container-interop",
-            "support": {
-                "issues": "https://github.com/container-interop/container-interop/issues",
-                "source": "https://github.com/container-interop/container-interop/tree/master"
-            },
-            "abandoned": "psr/container",
-            "time": "2017-02-14T19:40:03+00:00"
-        },
-        {
             "name": "laminas/laminas-cache",
-            "version": "3.0.x-dev",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache.git",
-                "reference": "86b47eb7b05bc4d24edafb3039494ba81405983b"
+                "reference": "8c5f5f43dbab6c74801dfe75852275d9f52d1b02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/86b47eb7b05bc4d24edafb3039494ba81405983b",
-                "reference": "86b47eb7b05bc4d24edafb3039494ba81405983b",
+                "url": "https://api.github.com/repos/laminas/laminas-cache/zipball/8c5f5f43dbab6c74801dfe75852275d9f52d1b02",
+                "reference": "8c5f5f43dbab6c74801dfe75852275d9f52d1b02",
                 "shasum": ""
             },
             "require": {
@@ -61,7 +25,7 @@
                 "laminas/laminas-eventmanager": "^3.4",
                 "laminas/laminas-servicemanager": "^3.7",
                 "laminas/laminas-stdlib": "^3.6",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0",
                 "psr/cache": "^1.0",
                 "psr/simple-cache": "^1.0",
                 "webmozart/assert": "^1.9"
@@ -74,11 +38,11 @@
                 "psr/simple-cache-implementation": "1.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-apcu": "2.0.x-dev",
-                "laminas/laminas-cache-storage-adapter-blackhole": "2.0.x-dev",
-                "laminas/laminas-cache-storage-adapter-filesystem": "2.0.x-dev",
-                "laminas/laminas-cache-storage-adapter-memory": "2.0.x-dev",
-                "laminas/laminas-cache-storage-adapter-test": "2.0.x-dev",
+                "laminas/laminas-cache-storage-adapter-apcu": "^2.0",
+                "laminas/laminas-cache-storage-adapter-blackhole": "^2.0",
+                "laminas/laminas-cache-storage-adapter-filesystem": "^2.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.0",
+                "laminas/laminas-cache-storage-adapter-test": "^2.3",
                 "laminas/laminas-cli": "^1.0",
                 "laminas/laminas-coding-standard": "~2.2.0",
                 "laminas/laminas-config-aggregator": "^1.5",
@@ -86,8 +50,8 @@
                 "laminas/laminas-serializer": "^2.6",
                 "phpbench/phpbench": "^1.0",
                 "phpunit/phpunit": "^9.5",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.9"
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.24"
             },
             "suggest": {
                 "laminas/laminas-cache-storage-adapter-apcu": "APCu implementation",
@@ -139,39 +103,40 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-11-17T15:17:24+00:00"
+            "time": "2022-08-10T14:24:21+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
-            "version": "3.4.0",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-eventmanager.git",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba"
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
-                "reference": "a93fd278c97b2d41ebbce5ba048a24e3e6f580ba",
+                "url": "https://api.github.com/repos/laminas/laminas-eventmanager/zipball/41f7209428f37cab9573365e361f4078209aaafa",
+                "reference": "41f7209428f37cab9573365e361f4078209aaafa",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+                "php": "^7.4 || ~8.0.0 || ~8.1.0"
             },
             "conflict": {
+                "container-interop/container-interop": "<1.2",
                 "zendframework/zend-eventmanager": "*"
             },
             "require-dev": {
-                "container-interop/container-interop": "^1.1",
                 "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-stdlib": "^3.6",
                 "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5.5"
+                "phpunit/phpunit": "^9.5.5",
+                "psr/container": "^1.1.2 || ^2.0.2"
             },
             "suggest": {
-                "container-interop/container-interop": "^1.1, to use the lazy listeners feature",
-                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature"
+                "laminas/laminas-stdlib": "^2.7.3 || ^3.0, to use the FilterChain feature",
+                "psr/container": "^1.1.2 || ^2.0.2, to use the lazy listeners feature"
             },
             "type": "library",
             "autoload": {
@@ -205,51 +170,50 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-09-07T22:35:32+00:00"
+            "time": "2022-04-06T21:05:17+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.7.0",
+            "version": "3.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4"
+                "reference": "863c66733740cd36ebf5e700f4258ef2c68a2a24"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
-                "reference": "2b0aee477fdbd3191af7c302b93dbc5fda0626f4",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/863c66733740cd36ebf5e700f4258ef2c68a2a24",
+                "reference": "863c66733740cd36ebf5e700f4258ef2c68a2a24",
                 "shasum": ""
             },
             "require": {
-                "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
+                "ext-psr": "*",
                 "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
             },
             "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
             },
             "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
+                "container-interop/container-interop": "^1.2.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~2.2.0",
-                "laminas/laminas-container-config-test": "^0.3",
+                "laminas/laminas-coding-standard": "~2.3.0",
+                "laminas/laminas-container-config-test": "^0.7",
                 "laminas/laminas-dependency-plugin": "^2.1.2",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.4",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4",
-                "psalm/plugin-phpunit": "^0.16.1",
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.17.0",
                 "vimeo/psalm": "^4.8"
             },
             "suggest": {
@@ -261,6 +225,9 @@
             ],
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -294,7 +261,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-07-24T19:33:07+00:00"
+            "time": "2022-07-27T14:58:17+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -356,68 +323,6 @@
             "time": "2022-07-27T12:28:58+00:00"
         },
         {
-            "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/88bf037259869891afce6504cacc4f8a07b24d0f",
-                "reference": "88bf037259869891afce6504cacc4f8a07b24d0f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.3 || ~8.0.0 || ~8.1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "psalm/plugin-phpunit": "^0.15.1",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.6"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "module": "Laminas\\ZendFrameworkBridge"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
-                "psr-4": {
-                    "Laminas\\ZendFrameworkBridge\\": "src//"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
-            "keywords": [
-                "ZendFramework",
-                "autoloading",
-                "laminas",
-                "zf"
-            ],
-            "support": {
-                "forum": "https://discourse.laminas.dev/",
-                "issues": "https://github.com/laminas/laminas-zendframework-bridge/issues",
-                "rss": "https://github.com/laminas/laminas-zendframework-bridge/releases.atom",
-                "source": "https://github.com/laminas/laminas-zendframework-bridge"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2021-12-21T14:34:37+00:00"
-        },
-        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -468,20 +373,20 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
-                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
+                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.0"
+                "php": ">=7.4.0"
             },
             "type": "library",
             "autoload": {
@@ -510,9 +415,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.1"
+                "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
-            "time": "2021-03-05T17:36:06+00:00"
+            "time": "2021-11-05T16:50:12+00:00"
         },
         {
             "name": "psr/simple-cache",
@@ -790,131 +695,6 @@
                 }
             ],
             "time": "2021-03-30T17:13:30+00:00"
-        },
-        {
-            "name": "cache/integration-tests",
-            "version": "0.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/integration-tests.git",
-                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/integration-tests/zipball/eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
-                "reference": "eda2e6b8bc5abcd623c8047e2345cda38dd6479e",
-                "shasum": ""
-            },
-            "require": {
-                "cache/tag-interop": "^1.0",
-                "php": ">=5.5.9",
-                "psr/cache": "~1.0"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<4.8.35|<5.4.3,>=5.0"
-            },
-            "require-dev": {
-                "cache/cache": "^1.0",
-                "illuminate/cache": "^5.4|^5.5|^5.6",
-                "mockery/mockery": "^1.0",
-                "symfony/cache": "^3.4.31|^4.3.4|^5.0",
-                "symfony/phpunit-bridge": "^5.1",
-                "tedivm/stash": "^0.14"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cache\\IntegrationTests\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Aaron Scherer",
-                    "email": "aequasi@gmail.com",
-                    "homepage": "https://github.com/aequasi"
-                },
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                }
-            ],
-            "description": "Integration tests for PSR-6 and PSR-16 cache implementations",
-            "homepage": "https://github.com/php-cache/integration-tests",
-            "keywords": [
-                "cache",
-                "psr16",
-                "psr6",
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/php-cache/integration-tests/issues",
-                "source": "https://github.com/php-cache/integration-tests/tree/0.17.0"
-            },
-            "time": "2020-11-03T12:52:23+00:00"
-        },
-        {
-            "name": "cache/tag-interop",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-cache/tag-interop.git",
-                "reference": "b062b1d735357da50edf8387f7a8696f3027d328"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/b062b1d735357da50edf8387f7a8696f3027d328",
-                "reference": "b062b1d735357da50edf8387f7a8696f3027d328",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0 || ^8.0",
-                "psr/cache": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Cache\\TagInterop\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Tobias Nyholm",
-                    "email": "tobias.nyholm@gmail.com",
-                    "homepage": "https://github.com/nyholm"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com",
-                    "homepage": "https://github.com/nicolas-grekas"
-                }
-            ],
-            "description": "Framework interoperable interfaces for tags",
-            "homepage": "https://www.php-cache.com/en/latest/",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr6",
-                "tag"
-            ],
-            "support": {
-                "issues": "https://github.com/php-cache/tag-interop/issues",
-                "source": "https://github.com/php-cache/tag-interop/tree/1.1.0"
-            },
-            "time": "2021-12-31T10:03:23+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -1492,37 +1272,35 @@
         },
         {
             "name": "laminas/laminas-cache-storage-adapter-test",
-            "version": "2.0.x-dev",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-cache-storage-adapter-test.git",
-                "reference": "a58ecac3df4c180b74d017c8ba9341151e47a854"
+                "reference": "d4346d8fdbc8a2b4c6656749f926c5c89a641109"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-test/zipball/a58ecac3df4c180b74d017c8ba9341151e47a854",
-                "reference": "a58ecac3df4c180b74d017c8ba9341151e47a854",
+                "url": "https://api.github.com/repos/laminas/laminas-cache-storage-adapter-test/zipball/d4346d8fdbc8a2b4c6656749f926c5c89a641109",
+                "reference": "d4346d8fdbc8a2b4c6656749f926c5c89a641109",
                 "shasum": ""
             },
             "require": {
-                "cache/integration-tests": "^0.17",
                 "container-interop/container-interop": "^1.2",
-                "laminas/laminas-cache": "^3.0",
-                "php": "^7.3 || ~8.0.0 || ~8.1.0",
-                "phpunit/phpunit": "^9.5.9"
+                "laminas/laminas-cache": "^3.1",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0",
+                "phpunit/phpunit": "^9.5.20",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "laminas/laminas-cache-storage-adapter-memory": "^1.1",
+                "laminas/laminas-cache-storage-adapter-apcu": "^2.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.0",
                 "laminas/laminas-coding-standard": "~2.3.0",
-                "psalm/plugin-phpunit": "^0.16.1",
-                "vimeo/psalm": "^4.7"
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.23.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
-                "files": [
-                    "autoload/phpunit-backward-compatibility.php"
-                ],
                 "psr-4": {
                     "LaminasTest\\Cache\\Storage\\Adapter\\": "src/"
                 }
@@ -1549,7 +1327,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-03-01T00:54:09+00:00"
+            "time": "2022-07-29T16:17:35+00:00"
         },
         {
             "name": "laminas/laminas-coding-standard",
@@ -4910,18 +4688,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "laminas/laminas-cache": 20,
-        "laminas/laminas-cache-storage-adapter-test": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0 || ~8.1.0"
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3.99"
+        "php": "7.4.99"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/src/BlackHole/AdapterPluginManagerDelegatorFactory.php
+++ b/src/BlackHole/AdapterPluginManagerDelegatorFactory.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Cache\Storage\Adapter\BlackHole;
 
-use Interop\Container\ContainerInterface;
 use Laminas\Cache\Storage\Adapter\BlackHole;
 use Laminas\Cache\Storage\AdapterPluginManager;
 use Laminas\ServiceManager\Factory\InvokableFactory;
+use Psr\Container\ContainerInterface;
 
 use function assert;
 

--- a/test/integration/Psr/CacheItemPool/BlackHoleIntegrationTest.php
+++ b/test/integration/Psr/CacheItemPool/BlackHoleIntegrationTest.php
@@ -12,38 +12,41 @@ final class BlackHoleIntegrationTest extends AbstractCacheItemPoolIntegrationTes
 {
     private const TEST_NOT_SUPPORTED_REASON = 'BlackHole never caches.';
 
-    /** @var array<string,string> */
-    protected $skippedTests = [
-        'testBasicUsage'                                   => self::TEST_NOT_SUPPORTED_REASON,
-        'testGetItem'                                      => self::TEST_NOT_SUPPORTED_REASON,
-        'testGetItems'                                     => self::TEST_NOT_SUPPORTED_REASON,
-        'testHasItem'                                      => self::TEST_NOT_SUPPORTED_REASON,
-        'testDeleteItems'                                  => self::TEST_NOT_SUPPORTED_REASON,
-        'testSave'                                         => self::TEST_NOT_SUPPORTED_REASON,
-        'testSaveWithoutExpire'                            => self::TEST_NOT_SUPPORTED_REASON,
-        'testDeferredSave'                                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testDeferredSaveWithoutCommit'                    => self::TEST_NOT_SUPPORTED_REASON,
-        'testCommit'                                       => self::TEST_NOT_SUPPORTED_REASON,
-        'testExpiresAt'                                    => self::TEST_NOT_SUPPORTED_REASON,
-        'testExpiresAtWithNull'                            => self::TEST_NOT_SUPPORTED_REASON,
-        'testExpiresAfterWithNull'                         => self::TEST_NOT_SUPPORTED_REASON,
-        'testKeyLength'                                    => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeString'                               => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeInteger'                              => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeNull'                                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeFloat'                                => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeBoolean'                              => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeArray'                                => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeObject'                               => self::TEST_NOT_SUPPORTED_REASON,
-        'testIsHit'                                        => self::TEST_NOT_SUPPORTED_REASON,
-        'testIsHitDeferred'                                => self::TEST_NOT_SUPPORTED_REASON,
-        'testSaveDeferredWhenChangingValues'               => self::TEST_NOT_SUPPORTED_REASON,
-        'testSaveDeferredOverwrite'                        => self::TEST_NOT_SUPPORTED_REASON,
-        'testSavingObject'                                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testHasItemReturnsFalseWhenDeferredItemIsExpired' => self::TEST_NOT_SUPPORTED_REASON,
-        'testBinaryData'                                   => self::TEST_NOT_SUPPORTED_REASON,
-        'testBasicUsageWithLongKey'                        => self::TEST_NOT_SUPPORTED_REASON,
-    ];
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skippedTests = [
+            'testBasicUsage'                                   => self::TEST_NOT_SUPPORTED_REASON,
+            'testGetItem'                                      => self::TEST_NOT_SUPPORTED_REASON,
+            'testGetItems'                                     => self::TEST_NOT_SUPPORTED_REASON,
+            'testHasItem'                                      => self::TEST_NOT_SUPPORTED_REASON,
+            'testDeleteItems'                                  => self::TEST_NOT_SUPPORTED_REASON,
+            'testSave'                                         => self::TEST_NOT_SUPPORTED_REASON,
+            'testSaveWithoutExpire'                            => self::TEST_NOT_SUPPORTED_REASON,
+            'testDeferredSave'                                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testDeferredSaveWithoutCommit'                    => self::TEST_NOT_SUPPORTED_REASON,
+            'testCommit'                                       => self::TEST_NOT_SUPPORTED_REASON,
+            'testExpiresAt'                                    => self::TEST_NOT_SUPPORTED_REASON,
+            'testExpiresAtWithNull'                            => self::TEST_NOT_SUPPORTED_REASON,
+            'testExpiresAfterWithNull'                         => self::TEST_NOT_SUPPORTED_REASON,
+            'testKeyLength'                                    => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeString'                               => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeInteger'                              => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeNull'                                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeFloat'                                => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeBoolean'                              => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeArray'                                => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeObject'                               => self::TEST_NOT_SUPPORTED_REASON,
+            'testIsHit'                                        => self::TEST_NOT_SUPPORTED_REASON,
+            'testIsHitDeferred'                                => self::TEST_NOT_SUPPORTED_REASON,
+            'testSaveDeferredWhenChangingValues'               => self::TEST_NOT_SUPPORTED_REASON,
+            'testSaveDeferredOverwrite'                        => self::TEST_NOT_SUPPORTED_REASON,
+            'testSavingObject'                                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testHasItemReturnsFalseWhenDeferredItemIsExpired' => self::TEST_NOT_SUPPORTED_REASON,
+            'testBinaryData'                                   => self::TEST_NOT_SUPPORTED_REASON,
+            'testBasicUsageWithLongKey'                        => self::TEST_NOT_SUPPORTED_REASON,
+        ];
+    }
 
     protected function createStorage(): StorageInterface
     {

--- a/test/integration/Psr/SimpleCache/BlackHoleIntegrationTest.php
+++ b/test/integration/Psr/SimpleCache/BlackHoleIntegrationTest.php
@@ -13,32 +13,35 @@ final class BlackHoleIntegrationTest extends AbstractSimpleCacheIntegrationTest
 {
     private const TEST_NOT_SUPPORTED_REASON = 'BlackHole never caches.';
 
-    /** @var array<string,string> */
-    protected $skippedTests = [
-        'testSet'                            => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultipleValidData'           => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetValidData'                   => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultipleValidKeys'           => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetValidKeys'                   => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeObject'                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeArray'                  => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeBoolean'                => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeFloat'                  => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeInteger'                => self::TEST_NOT_SUPPORTED_REASON,
-        'testDataTypeString'                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testHas'                            => self::TEST_NOT_SUPPORTED_REASON,
-        'testGetMultipleWithGenerator'       => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultipleWithGenerator'       => self::TEST_NOT_SUPPORTED_REASON,
-        'testGetMultiple'                    => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultipleTtl'                 => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultiple'                    => self::TEST_NOT_SUPPORTED_REASON,
-        'testGet'                            => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetTtl'                         => self::TEST_NOT_SUPPORTED_REASON,
-        'testObjectDoesNotChangeInCache'     => self::TEST_NOT_SUPPORTED_REASON,
-        'testBasicUsageWithLongKey'          => self::TEST_NOT_SUPPORTED_REASON,
-        'testBinaryData'                     => self::TEST_NOT_SUPPORTED_REASON,
-        'testSetMultipleWithIntegerArrayKey' => self::TEST_NOT_SUPPORTED_REASON,
-    ];
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->skippedTests = [
+            'testSet'                            => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultipleValidData'           => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetValidData'                   => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultipleValidKeys'           => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetValidKeys'                   => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeObject'                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeArray'                  => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeBoolean'                => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeFloat'                  => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeInteger'                => self::TEST_NOT_SUPPORTED_REASON,
+            'testDataTypeString'                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testHas'                            => self::TEST_NOT_SUPPORTED_REASON,
+            'testGetMultipleWithGenerator'       => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultipleWithGenerator'       => self::TEST_NOT_SUPPORTED_REASON,
+            'testGetMultiple'                    => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultipleTtl'                 => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultiple'                    => self::TEST_NOT_SUPPORTED_REASON,
+            'testGet'                            => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetTtl'                         => self::TEST_NOT_SUPPORTED_REASON,
+            'testObjectDoesNotChangeInCache'     => self::TEST_NOT_SUPPORTED_REASON,
+            'testBasicUsageWithLongKey'          => self::TEST_NOT_SUPPORTED_REASON,
+            'testBinaryData'                     => self::TEST_NOT_SUPPORTED_REASON,
+            'testSetMultipleWithIntegerArrayKey' => self::TEST_NOT_SUPPORTED_REASON,
+        ];
+    }
 
     protected function createStorage(): StorageInterface
     {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

This also adds a conflict with `laminas-servicemanager` <3.11 to ensure we can remove `container-interop` and drops support for PHP 7.3.
